### PR TITLE
Enabled several nb and poisson losses

### DIFF
--- a/src/multigrate/model/_multivae.py
+++ b/src/multigrate/model/_multivae.py
@@ -291,6 +291,7 @@ class MultiVAE(BaseModelClass, ArchesMixin):
         weight_decay: float = 1e-3,
         eps: float = 1e-08,
         early_stopping: bool = True,
+        early_stopping_patience = 50,
         save_best: bool = True,
         check_val_every_n_epoch: int | None = None,
         n_epochs_kl_warmup: int | None = None,
@@ -419,7 +420,7 @@ class MultiVAE(BaseModelClass, ArchesMixin):
             early_stopping=early_stopping,
             check_val_every_n_epoch=check_val_every_n_epoch,
             early_stopping_monitor="reconstruction_loss_validation",
-            early_stopping_patience=50,
+            early_stopping_patience=early_stopping_patience,
             enable_checkpointing=True,
             **kwargs,
         )

--- a/src/multigrate/module/_multivae_torch.py
+++ b/src/multigrate/module/_multivae_torch.py
@@ -181,11 +181,13 @@ class MultiVAETorch(BaseModuleClass):
 
         # assume for now that can only use nb/zinb once, i.e. for RNA-seq modality
         # TODO: add check for multiple nb/zinb losses given
-        self.theta = None
+        self.theta = []
+        j = []
         for i, loss in enumerate(losses):
             if loss in ["nb", "zinb"]:
-                self.theta = torch.nn.Parameter(torch.randn(self.input_dims[i], num_groups))
-                break
+                self.theta.append(torch.nn.Parameter(torch.randn(self.input_dims[i], num_groups)))
+            else:
+                self.theta.append([])
 
         # modality encoders
         cond_dim_enc = cond_dim * (len(cat_covariate_dims) + len(cont_covariate_dims)) if self.condition_encoders else 0
@@ -307,6 +309,7 @@ class MultiVAETorch(BaseModuleClass):
         return x
 
     def _product_of_experts(self, mus, logvars, masks):
+        #print(mus, logvars, masks)
         vars = torch.exp(logvars)
         masks = masks.unsqueeze(-1).repeat(1, 1, vars.shape[-1])
         mus_joint = torch.sum(mus * masks / vars, dim=1)
@@ -657,7 +660,7 @@ class MultiVAETorch(BaseModuleClass):
                 dec_mean = r
                 size_factor_view = size_factor.expand(dec_mean.size(0), dec_mean.size(1))
                 dec_mean = dec_mean * size_factor_view
-                dispersion = self.theta.T[group.squeeze().long()]
+                dispersion = self.theta[i].to(self.device).T[group.squeeze().long()]
                 dispersion = torch.exp(dispersion)
                 nb_loss = torch.sum(NegativeBinomial(mu=dec_mean, theta=dispersion).log_prob(x), dim=-1)
                 nb_loss = loss_coefs[str(i)] * nb_loss
@@ -666,9 +669,9 @@ class MultiVAETorch(BaseModuleClass):
                 dec_mean, dec_dropout = r
                 dec_mean = dec_mean.squeeze()
                 dec_dropout = dec_dropout.squeeze()
-                size_factor_view = size_factor.unsqueeze(1).expand(dec_mean.size(0), dec_mean.size(1))
+                size_factor_view = size_factor.expand(dec_mean.size(0), dec_mean.size(1))
                 dec_mean = dec_mean * size_factor_view
-                dispersion = self.theta.T[group.squeeze().long()]
+                dispersion = self.theta[i].to(self.device).T[group.squeeze().long()]
                 dispersion = torch.exp(dispersion)
                 zinb_loss = torch.sum(
                     ZeroInflatedNegativeBinomial(mu=dec_mean, theta=dispersion, zi_logits=dec_dropout).log_prob(x),


### PR DESCRIPTION
Enabled multiple nb or poisson losses for, e.g nano-CUT&Tag data integration. Exposed early stopping patience argument in the `train` to users.